### PR TITLE
Clean up: slicing device usage

### DIFF
--- a/schemas/device/slicingDeviceUsage.schema.tpl.json
+++ b/schemas/device/slicingDeviceUsage.schema.tpl.json
@@ -1,14 +1,7 @@
 {
-  "_type": "https://openminds.ebrains.eu/specimenPrep/SlicingDeviceUsage",
-  "_categories": [
-    "deviceUsage"
-  ],
-  "required": [
-    "device",
-    "sliceThickness",
-    "slicingPlane"
-  ],
-  "properties": {
+  "_type": "https://openminds.ebrains.eu/ephys/SlicingDeviceUsage",
+  "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
+  "properties": {   
     "device": {
       "_instruction": "Add the slicing device used.",
       "_linkedTypes": [
@@ -16,13 +9,13 @@
       ]
     },
     "oscillationAmplitude": {
-      "_instruction": "Define the oscillation amplitude of the blade used in this tissue sample slicing.",
+      "_instruction": "Enter the oscillation amplitude of the blade from the slicing device during its use.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]
     },
     "sliceThickness": {
-      "_instruction": "Define slice thickness used in this tissue sample slicing.",
+      "_instruction": "Enter the defined slice thickness during the use of this slicing device.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue",
         "https://openminds.ebrains.eu/core/QuantitativeValueRange"
@@ -32,26 +25,26 @@
       "type": "array",
       "minItems": 1,
       "maxItems": 2,
-      "_instruction": "Define one or two slicing angles in relation to the slicing plane used in this tissue sample slicing.",
+      "_instruction": "Enter all slicing angles (intentional or unintentional) in relation to the slicing plane used during this activity.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "https://openminds.ebrains.eu/core/NumericalParameter"
+        "https://openminds.ebrains.eu/core/NumericalProperty"
       ]
     },
     "slicingPlane": {
-      "_instruction": "Define the general anatomical plane of the tissue sample(s) that result from this tissue sample slicing.",
+      "_instruction": "Add the anatomical plane that best describes the slicing direction of the tissue sample(s) during the use of this slicing device.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/AnatomicalPlane"
       ]
     },
     "slicingSpeed": {
-      "_instruction": "Define the slicing speed used in this tissue sample slicing.",
+      "_instruction": "Enter the defined slicing speed during the use of this slicing device.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]
     },
     "vibrationFrequency": {
-      "_instruction": "If applicable, define the vibration frequency used in this tissue sample slicing.",
+      "_instruction": "Enter the defined vibration frequency during the use of this slicing device.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]

--- a/schemas/device/slicingDeviceUsage.schema.tpl.json
+++ b/schemas/device/slicingDeviceUsage.schema.tpl.json
@@ -1,6 +1,10 @@
 {
   "_type": "https://openminds.ebrains.eu/ephys/SlicingDeviceUsage",
-  "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",
+  "_extends": "/core/schemas/research/deviceUsage.schema.tpl.json",  
+  "required": [
+    "sliceThickness",
+    "slicingPlane"
+  ],
   "properties": {   
     "device": {
       "_instruction": "Add the slicing device used.",


### PR DESCRIPTION
MINOR changes:
- improved instructions
- establish alphabetical order
- removed category because it is now inherited from concept
- fixed error in `slicingAngle` links, which needs to link to `numericalProperty` instead of `numericalParameter`

MAJOR changes:
- extends concept schema for device usage

SPECIAL ATTENTION:
- received `metadataLocation`, `lookupLabel` and `usedSpecimen` from concept as all other device usages